### PR TITLE
Update docs for FAC15

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ _13:00-14:00 Lunch_
 11:30-13:30 [React with dynamic data](https://github.com/sofiapoh/react-dynamic-data-workshop)  
 _13:30-14:30 Lunch_  
 14:30-16:30 [Testing React components](https://github.com/oliverjam/learn-react-testing)  
-16:30-17:30 [Project set-up](https://github.com/oliverjam/fac-react-project)  
+16:30-17:30 [Project set-up](https://github.com/oliverjam/minimal-react-setup)  
 17:30-18:00 Project planning  
 
 ### Day 3

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 11:00-11:30 [Modern frontend & how React fits in](https://hackmd.io/p/SJauYz6EM#) (talk/discussion)  
 11:30-13:00 [React API](https://github.com/oliverjam/intro-react-workshop) (workshop)  
 _13:00-14:00 Lunch_  
-14:00-15:00 [React API](https://github.com/oliverjam/intro-react-workshop) (workshop continued)  
-15:00-16:00 [Build a stopwatch](https://github.com/oliverjam/intro-react-workshop/blob/master/workshop-top-notch-stopwatch) (mini project)  
+14:00-16:30 [React API](https://github.com/oliverjam/intro-react-workshop) (workshop continued)  
+16:30-18:00 [Build a stopwatch](https://github.com/oliverjam/intro-react-workshop/blob/master/workshop-top-notch-stopwatch) (mini project)  
 
 ### Day 2
 
@@ -54,7 +54,7 @@ _13:00-14:00 Lunch_
 
 10:00-13:00 Projects  
 _13:00-14:00 Lunch_  
-14:00-16:00 Projects  
+14:00-18:00 Projects  
 
 ### Day 5
 10:00-11:00 Code review  

--- a/project.md
+++ b/project.md
@@ -1,0 +1,39 @@
+# Tamagotchi Project!
+
+The goal is to build an interactive game-like thing that uses data from an API.
+
+It should:
+
+* Accept some user input (e.g. a username)
+* Query an API (e.g. the [Github API](https://developer.github.com/v3/), or any other [fun one](https://www.potterapi.com/))
+* Populate a UI with API data
+* Have some form of persistent state and interactivity, e.g.
+  * A hunger bar that decreases over time and is topped up when you feed them stars
+  * A button to add more users to your collection
+* Have integration tests! (and units tests if they're relevant)
+
+Try to:
+
+* Write modular code: one component per file
+* Separate your container logic from presentational components
+
+### Stretch goals
+
+* Save your state to localstorage so you can leave the page and come back later
+* Have a button to add more copies of the game
+* Make it look sick
+
+### Examples
+
+"interactive game-like thing" is a bit vague, so here are two example apps:
+
+[Oli's Tamagotchi](https://tamagotchi.netlify.com)  
+[Zooey's Drake thing](https://fuckin-yolo.netlify.com/)
+
+### Setup
+
+We'll go through the project setup together. All the information is in [this repo](https://github.com/oliverjam/minimal-react-setup)
+
+### Deployment
+
+You can deploy your app to [Netlify](https://netlify.com) (or any other static host). There are [more instructions](https://github.com/oliverjam/minimal-react-setup/blob/master/docs/deploying.md) in the setup repo.


### PR DESCRIPTION
- Put timetable back to normal, since as far as I know there are no client workshops to fit in this time.
- Add the project instructions to this repo instead of the project setup repo